### PR TITLE
Fix x.com videos issue

### DIFF
--- a/lib/imageUtils.js
+++ b/lib/imageUtils.js
@@ -301,15 +301,20 @@ function prepareAndHandleVideo(videoElement, singleImageVerification) {
   if (!videoElement.src) {
     const sourceElement = videoElement.querySelector('source');
     if (sourceElement) {
+      sourceElement.setAttribute('c2paId', baseId);
       const src = sourceElement.getAttribute('src');
-      videoElement.src = src;
+      setImageDataURI(sourceElement).then((imageDataURI) => {
+        sourceElement.dataURI = imageDataURI;
+        getC2PAManifest(sourceElement, addIconForImage, singleImageVerification);
+      });
+      // videoElement.src = 'https://storage.googleapis.com/cats-eye-images/digimarc_ps256.mp4';
     }
+  } else {
+    setImageDataURI(videoElement).then((imageDataURI) => {
+      videoElement.dataURI = imageDataURI;
+      getC2PAManifest(videoElement, addIconForImage, singleImageVerification);
+    });
   }
-
-  setImageDataURI(videoElement).then((imageDataURI) => {
-    videoElement.dataURI = imageDataURI;
-    getC2PAManifest(videoElement, addIconForImage, singleImageVerification);
-  });
 }
 
 function showElementAndDescendants(element) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "C2PA Content Credentials",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "Verify and display manifests for images and videos embedding C2PA Content Credentials.",
     "icons": {
         "16": "images/icons/icon.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "C2PA Content Credentials",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "Verify and display manifests for images and videos embedding C2PA Content Credentials.",
     "icons": {
         "16": "images/icons/icon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "c2pa-content-credentials-extension",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "Verify and display manifests for images embedding C2PA Content Credentials.",
     "main": "content.js",
     "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "c2pa-content-credentials-extension",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "Verify and display manifests for images embedding C2PA Content Credentials.",
     "main": "content.js",
     "type": "module",


### PR DESCRIPTION
- Videos on X used to crash, and are not playable when the automatic mode is enabled. so I fix it when <source> tag is used inside <video> tags. (especially on x.com)

- Update package.json and manifest.json to v0.0.6